### PR TITLE
Remove font setting from classes document & usfm

### DIFF
--- a/src/components/Usfm.css
+++ b/src/components/Usfm.css
@@ -1,7 +1,3 @@
-.usfm .document {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
 .usfm .section {
   width: 100%;
 }


### PR DESCRIPTION
This simplifies inline font setting with font-detect-rhl when preview is false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-box3/simple-text-editor-rcl/9)
<!-- Reviewable:end -->
